### PR TITLE
Base frame timestamp off epicsTS

### DIFF
--- a/App/src/QImaging.cpp
+++ b/App/src/QImaging.cpp
@@ -472,9 +472,8 @@ void QImage::consumerTask()
 			if ((arrayCallbacks))
 			{
 				// Put the frame number and time stamp into the buffer
-				updateTimeStamp(&ndArray->epicsTS);
 				pFrames[frameId]->ndArray->uniqueId = frameId;
-				pFrames[frameId]->ndArray->timeStamp = ndArray->epicsTS.secPastEpoch + ndArray->epicsTS.nsec / 1.e9;
+				updateTimeStamps(pFrames[frameId]->ndArray);
 				// Get any attributes that have been defined for this driver
 				this->getAttributes(pFrames[frameId]->ndArray->pAttributeList);
 				// Call the NDArray callback

--- a/App/src/QImaging.cpp
+++ b/App/src/QImaging.cpp
@@ -472,10 +472,9 @@ void QImage::consumerTask()
 			if ((arrayCallbacks))
 			{
 				// Put the frame number and time stamp into the buffer
-				// Set the the start time
-				epicsTimeGetCurrent(&startTime);
+				updateTimeStamp(&ndArray->epicsTS);
 				pFrames[frameId]->ndArray->uniqueId = frameId;
-				pFrames[frameId]->ndArray->timeStamp = startTime.secPastEpoch + startTime.nsec / 1.e9;
+				pFrames[frameId]->ndArray->timeStamp = ndArray->epicsTS.secPastEpoch + ndArray->epicsTS.nsec / 1.e9;
 				// Get any attributes that have been defined for this driver
 				this->getAttributes(pFrames[frameId]->ndArray->pAttributeList);
 				// Call the NDArray callback

--- a/Support/QImaging.h
+++ b/Support/QImaging.h
@@ -158,7 +158,6 @@ public:
 	};
 
 	// Our data
-	epicsTimeStamp  startTime;
 	epicsEventId    stopEventId;
 	epicsEventId m_acquireEventId;
 	epicsMutex freeFrameMutex;


### PR DESCRIPTION
Part of a series of PRs for AreaDetector repos that sets the outgoing frames' timeStamp member to be equal to the frame's epicsTS member, updated with updateTimeStamp, when not retreiving a timestamp from hardware.